### PR TITLE
Update dependencies and migrate to kotlin.time.Instant

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,28 @@ class KoinServiceLocator(private val koin: Koin) : ServiceLocator {
 
 Check the `sample/` app with the "Pet Store" for a full example.
 
+
+## Plugin Development notes
+
+### Setup
+
+The most practical way is to open on IntelliJ the sample app. The `sample/settings.gradle` points to the source code of the plugin and applies it to the project.
+
+After gradle import/index the source code from the plugin will be linked and display on the IDE and it's trivial to do the changes on the plugin and see the effects on the sample. 
+
+### Disable task caching/auto execution
+
+It might become necessary during the plugin development to disable the task caching and auto-execution.
+
+For that:
+- In `KtorServerExtension.kt` comment out `OutputDirectory` and `Optional` from `outputFolder` and add `@get:Console`
+- In `ApplyGenerateKtorServer.kt` and replace in both `sourceSet.<type>.srcDirs(task)` to `sourceSet.<type>.srcDirs(target.defaultOutput)`.
+
+This way you can control when the code is generated, but it will still be linked to the `sourceSet`
+
 ## Authors <a name = "authors"></a>
 
 - [@rvp-diconium](https://github.com/rvp-diconium)
 
-See also the list of [contributors](https://github.com/diconium/mcc-network-generator/contributors) who participated in
+See also the list of [contributors](https://github.com/diconium/kebab-krafter/contributors) who participated in
 this project.

--- a/kebab-krafter/gradle/libs.versions.toml
+++ b/kebab-krafter/gradle/libs.versions.toml
@@ -37,14 +37,15 @@ ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint_version" 
 
 [versions]
 
-kotlin_version = "2.2.10"
+kotlin_version = "2.2.20"
 kotlin_poet = "2.2.0"
-ktor_version = "3.2.3"
+ktor_version = "3.3.1"
 json_org_version = "20250517"
-snakeyaml_version = "2.4"
-swagger_parser_version = "2.1.32"
+snakeyaml_version = "2.5"
+swagger_parser_version = "2.1.34"
 gradle_plugin_version = "1.3.1"
-licensee_version = "1.13.0"
+##                 ⬆ = "2.0.0"
+licensee_version = "1.14.1"
 ktlint_version = "13.1.0"
 
 [libraries]

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -52,6 +52,7 @@ kotlin {
     jvmToolchain(21)
     compilerOptions {
         jvmTarget.set(JvmTarget.JVM_21)
+        optIn.add("kotlin.time.ExperimentalTime")
     }
 }
 

--- a/sample/gradle/libs.versions.toml
+++ b/sample/gradle/libs.versions.toml
@@ -21,14 +21,14 @@ ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint_version" 
 
 [versions]
 
-kotlin_version = "2.2.10"
-licensee_version = "1.13.0"
+kotlin_version = "2.2.20"
+licensee_version = "1.14.1"
 ktlint_version = "13.1.0"
-ktor_version = "3.2.3"
+ktor_version = "3.3.1"
 kotlin_serialization_version = "1.9.0"
-koin_version = "4.1.0"
-logback_version = "1.5.18"
-kotlinx_datetime_versiom = "0.7.1-0.6.x-compat"
+koin_version = "4.1.1"
+logback_version = "1.5.19"
+kotlinx_datetime_versiom = "0.7.1"
 
 [libraries]
 

--- a/sample/src/main/kotlin/com/diconium/mobile/tools/kebabkrafter/sample/db/Database.kt
+++ b/sample/src/main/kotlin/com/diconium/mobile/tools/kebabkrafter/sample/db/Database.kt
@@ -2,6 +2,7 @@ package com.diconium.mobile.tools.kebabkrafter.sample.db
 
 import com.diconium.mobile.tools.kebabkrafter.sample.gen.petstore.models.v1.Pet
 import com.diconium.mobile.tools.kebabkrafter.sample.gen.petstore.models.v1.PetsResponse
+import kotlin.time.Instant
 
 // here's some fake database responses
 // just for illustration purposes
@@ -10,8 +11,8 @@ object Database {
     private var ids = 1
 
     private val data = mutableListOf(
-        Pet.Cat("id.0", "Miau", "brown", 2.3f, null),
-        Pet.Dog("id.1", "Toto", "white", 7.3f, 6, "bulldog", null),
+        Pet.Cat("id.0", "Miau", "brown", 2.3f, Instant.fromEpochMilliseconds(1676036625000)),
+        Pet.Dog("id.1", "Toto", "white", 7.3f, 6, "bulldog", Instant.fromEpochMilliseconds(1531622625000)),
     )
 
     val getAllPets: suspend () -> PetsResponse = {

--- a/sample/src/main/kotlin/com/diconium/mobile/tools/kebabkrafter/sample/mock/v1/MockGetPetController.kt
+++ b/sample/src/main/kotlin/com/diconium/mobile/tools/kebabkrafter/sample/mock/v1/MockGetPetController.kt
@@ -4,6 +4,7 @@ import com.diconium.mobile.tools.kebabkrafter.sample.CallScope
 import com.diconium.mobile.tools.kebabkrafter.sample.gen.petstore.controllers.v1.GetPet
 import com.diconium.mobile.tools.kebabkrafter.sample.gen.petstore.models.v1.Pet
 import com.diconium.mobile.tools.kebabkrafter.sample.gen.petstore.models.v1.PetsResponse
+import kotlin.time.Instant
 
 class MockGetPetController : GetPet {
     override suspend fun CallScope.execute(type: String?, page: Int?): PetsResponse {
@@ -12,8 +13,8 @@ class MockGetPetController : GetPet {
             count = 2,
             page = 0,
             pets = listOf(
-                Pet.Cat("id.0", "Miau", "brown", 2.3f, null),
-                Pet.Dog("id.1", "Toto", "white", 7.3f, 6, "bulldog", null),
+                Pet.Cat("id.0", "Miau", "brown", 2.3f, Instant.fromEpochMilliseconds(0)),
+                Pet.Dog("id.1", "Toto", "white", 7.3f, 6, "bulldog", Instant.fromEpochMilliseconds(1)),
             ),
         )
     }


### PR DESCRIPTION
## What does this PR introduce?

- Update dependencies
- migrate to kotlin.time.Instant Fix #13
- also apply OptIn(ExperimentalSerializationApi) Fix #12

## Resolved or linked issues?

#12  and #13 


### Before

```kotlin
@Serializable
@JsonClassDiscriminator("petType")
public sealed class Pet {
  @Serializable
  @SerialName("cat")
  public data class Cat(
      val dateOfBirth: Instant? = null   <<<< this gives deprecated warning
```

### After

```kotlin
@Serializable
@JsonClassDiscriminator("petType")
@OptIn(ExperimentalSerializationApi::class)
public sealed class Pet {
  /**
   * A cat
   */
  @Serializable
  @OptIn(ExperimentalTime::class)
  @SerialName("cat")
  public data class Cat(
      val dateOfBirth: Instant? = null   <<<< uses the new kotlin.time.Instant
```