### PR TITLE
Closes #23 add support for double type.

### DIFF
--- a/kebab-krafter/src/main/kotlin/com/diconium/mobile/tools/kebabkrafter/generator/dataclasses/DataClassesGenerator.kt
+++ b/kebab-krafter/src/main/kotlin/com/diconium/mobile/tools/kebabkrafter/generator/dataclasses/DataClassesGenerator.kt
@@ -55,7 +55,6 @@ class DataClassesGenerator(
 
     private fun generateTypeSpecBuilder(dataClass: SpecModel): TypeSpec.Builder =
         TypeSpec.classBuilder(dataClass.asClassName).apply {
-
             optInExperimentalTime = false
 
             dataClass.description?.let(::addKdoc)
@@ -170,7 +169,6 @@ class DataClassesGenerator(
             addModifiers(KModifier.SEALED)
             addAnnotation(Serializable::class)
             addJsonDiscriminator?.let {
-
                 addAnnotation(
                     AnnotationSpec
                         .builder(jsonDiscriminator)
@@ -196,11 +194,12 @@ class DataClassesGenerator(
     }
 
     private fun SpecField.Type.toTypeName(enumLookup: Map<SpecField.Type.Enum, TypeName>): TypeName = when (this) {
-        SpecField.Type.Boolean -> Boolean::class.asTypeName()
-        SpecField.Type.Float -> Float::class.asTypeName()
-        SpecField.Type.Int -> Int::class.asTypeName()
-        SpecField.Type.String -> String::class.asTypeName()
-        SpecField.Type.Date -> {
+        is SpecField.Type.Boolean -> Boolean::class.asTypeName()
+        is SpecField.Type.Float -> Float::class.asTypeName()
+        is SpecField.Type.Double -> Double::class.asTypeName()
+        is SpecField.Type.Int -> Int::class.asTypeName()
+        is SpecField.Type.String -> String::class.asTypeName()
+        is SpecField.Type.Date -> {
             optInExperimentalTime = true
             kotlinTimeInstant
         }

--- a/kebab-krafter/src/main/kotlin/com/diconium/mobile/tools/kebabkrafter/models/SpecModel.kt
+++ b/kebab-krafter/src/main/kotlin/com/diconium/mobile/tools/kebabkrafter/models/SpecModel.kt
@@ -42,6 +42,7 @@ data class SpecField(val name: String, val type: Type, val isRequired: Boolean, 
         data object Int : Type
         data object Boolean : Type
         data object Float : Type
+        data object Double : Type
         data object Date : Type
         data class SealedSerializationDiscriminator(val value: kotlin.String) : Type
         data class DataModel(val id: kotlin.String) : Type

--- a/kebab-krafter/src/main/kotlin/com/diconium/mobile/tools/kebabkrafter/parser/JsonSchema.kt
+++ b/kebab-krafter/src/main/kotlin/com/diconium/mobile/tools/kebabkrafter/parser/JsonSchema.kt
@@ -21,7 +21,7 @@ data class JsonSchema(
 
         val description: String?,
 
-        /** format is used to classic the `number` type */
+        /** format is used to classify the `type` */
         val format: String?,
         @SerialName("\$ref")
         val ref: String?,

--- a/kebab-krafter/src/main/kotlin/com/diconium/mobile/tools/kebabkrafter/parser/SwaggerParser.kt
+++ b/kebab-krafter/src/main/kotlin/com/diconium/mobile/tools/kebabkrafter/parser/SwaggerParser.kt
@@ -372,7 +372,11 @@ private fun JsonSchema.Item.asType(): SpecField.Type? = when (type) {
 
     "boolean" -> SpecField.Type.Boolean
     "integer" -> SpecField.Type.Int
-    "number" -> SpecField.Type.Float
+    "number" -> when {
+        format == "double" -> SpecField.Type.Double
+        else -> SpecField.Type.Float
+    }
+
     else -> null
 }
 

--- a/kebab-krafter/src/main/kotlin/com/diconium/mobile/tools/kebabkrafter/plugin/server/ApplyGenerateKtorServer.kt
+++ b/kebab-krafter/src/main/kotlin/com/diconium/mobile/tools/kebabkrafter/plugin/server/ApplyGenerateKtorServer.kt
@@ -16,7 +16,6 @@ import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.SourceSetContainer
 
 fun applyGenerateKtorServer(target: Project) {
-
     // create extension
     val ktorServerInput = target.extensions.create("ktorServer", KtorServerExtension::class.java)
 
@@ -55,7 +54,6 @@ private val SourceSetContainer.main: NamedDomainObjectProvider<SourceSet>
 private val SourceSet.kotlin: SourceDirectorySet
     get() = (this as ExtensionAware).extensions.getByName("kotlin")
         as SourceDirectorySet
-
 
 private class DefaultEndpointTransformer : EndpointTransformer {
     override fun transform(endpoint: Endpoint) = endpoint

--- a/kebab-krafter/src/main/kotlin/com/diconium/mobile/tools/kebabkrafter/plugin/server/GenerateKtorServerTask.kt
+++ b/kebab-krafter/src/main/kotlin/com/diconium/mobile/tools/kebabkrafter/plugin/server/GenerateKtorServerTask.kt
@@ -26,7 +26,6 @@ abstract class GenerateKtorServerTask : DefaultTask() {
 
     private fun generateKtorServerFor() {
         with(ktorServerInput.get()) {
-
             generateKtorServerFor(
                 packageName = packageName.get(),
                 baseDir = outputFolder.get().asFile,
@@ -40,7 +39,6 @@ abstract class GenerateKtorServerTask : DefaultTask() {
                 },
 
                 transformers = with(ktorServerInput.get().transformerSpec) {
-
                     // implementation notes:
                     //
                     // That's a very cheeky piece of code that I'm still unsure if genius or stupid.

--- a/kebab-krafter/src/main/kotlin/com/diconium/mobile/tools/kebabkrafter/plugin/server/KtorServerExtension.kt
+++ b/kebab-krafter/src/main/kotlin/com/diconium/mobile/tools/kebabkrafter/plugin/server/KtorServerExtension.kt
@@ -105,5 +105,3 @@ interface KtorServerExtension {
     }
 //endregion
 }
-
-

--- a/kebab-krafter/src/main/kotlin/com/diconium/mobile/tools/kebabkrafter/plugin/server/TransformerSpec.kt
+++ b/kebab-krafter/src/main/kotlin/com/diconium/mobile/tools/kebabkrafter/plugin/server/TransformerSpec.kt
@@ -34,7 +34,6 @@ interface TransformerSpec {
     @get:Input
     val ktorMapper: Property<Class<out KtorMapper>>
 
-
     fun ktorMapper(block: KtorMapper) {
         ktorMapper.set(block::class.java)
     }

--- a/sample/src/main/resources/petstore/schemas/v1/Cat.json
+++ b/sample/src/main/resources/petstore/schemas/v1/Cat.json
@@ -42,6 +42,10 @@
       "type": "string",
       "format": "date-time",
       "example": "2020-07-02T14:23:04.000Z"
+    },
+    "location" : {
+      "description": "Where is the cat",
+      "$ref": "./Location.json"
     }
   }
 }

--- a/sample/src/main/resources/petstore/schemas/v1/Dog.json
+++ b/sample/src/main/resources/petstore/schemas/v1/Dog.json
@@ -53,6 +53,10 @@
       "type": "string",
       "format": "date-time",
       "example": "2020-07-02T14:23:04.000Z"
+    },
+    "location" : {
+      "description": "Where is the dog",
+      "$ref": "./Location.json"
     }
   }
 }

--- a/sample/src/main/resources/petstore/schemas/v1/Location.json
+++ b/sample/src/main/resources/petstore/schemas/v1/Location.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "http://json-schema.org/draft/2020-12/schema#",
+    "description": "A place on earth",
+    "type": "object",
+    "required": [
+        "latitude",
+        "longitude"
+    ],
+    "properties": {
+        "latitude": {
+            "description": "geographic coordinate that specifies the north-south position of a point on the surface of the Earth",
+            "type": "number",
+            "format": "double"
+        },
+        "longitude": {
+            "description": "geographic coordinate that specifies the east-west position of a point on the surface of the Earth",
+            "type": "number",
+            "format": "double"
+        }
+    }
+}

--- a/sample/src/main/resources/petstore/schemas/v1/Parrot.json
+++ b/sample/src/main/resources/petstore/schemas/v1/Parrot.json
@@ -34,6 +34,10 @@
       "type": "string",
       "format": "date-time",
       "example": "2020-07-02T14:23:04.000Z"
+    },
+    "location" : {
+      "description": "Where is the parrot",
+      "$ref": "./Location.json"
     }
   }
 }


### PR DESCRIPTION
## What does this PR introduce?

- add double type to the model specification
- add parsing of `number`+`double` to represent a Double precision floating point number
- add double to the data class generator
- includes to the sample a `Location.json` type with lat/lng and all the pet types can have an optional location.

also ran ktlintFormat, so there's a couple of random line breaks change

## Resolved or linked issues?

close #23 

## Implementation note:

`number`+`double` is not officially part of the JSON schema, but the schema does allow for custom formats as explained in the link below https://json-schema.org/draft/2020-12/json-schema-validation#name-custom-format-attributes

So we added this custom format by borrowing from swagger definition, which explicitly defines number format double and float as explained in the link below https://swagger.io/docs/specification/v3_0/data-models/data-types/#numbers


## Example generated `Location`:
```Kotlin
import kotlin.Double
import kotlinx.serialization.SerialName
import kotlinx.serialization.Serializable

/**
 * A place on earth
 */
@Serializable
public data class Location(
  /**
   * geographic coordinate that specifies the north-south position of a point on the surface of the Earth
   */
  @SerialName("latitude")
  public val latitude: Double,
  /**
   * geographic coordinate that specifies the east-west position of a point on the surface of the Earth
   */
  @SerialName("longitude")
  public val longitude: Double,
)

```